### PR TITLE
Replace jsoup with ksoup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This allows full control over text appearance of elements like headings, italics
 ---
 
 ## **🔧 How It Works**
-- **Parses HTML using Jsoup**
+- **Parses HTML using Ksoup**
 - **Maps HTML tags to Compose UI components**
 - **Map CSS styling for each HTML tag to TextStyle and passes on to individual render** 
 - **Uses `LazyColumn` for efficient rendering**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,9 @@ android {
 }
 
 dependencies {
+    val composeBom = platform(libs.compose.bom)
+    implementation(composeBom)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.material3)
     implementation(project(":nativehtml"))
 }

--- a/app/src/main/java/io/github/malikshairali/nativehtmldemo/MainActivity.kt
+++ b/app/src/main/java/io/github/malikshairali/nativehtmldemo/MainActivity.kt
@@ -3,6 +3,12 @@ package io.github.malikshairali.nativehtmldemo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
@@ -12,13 +18,20 @@ import io.github.malikshairali.nativehtml.style.StyleRegistry
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         // Override default styles
         StyleRegistry.setStyle("h1", TextStyle(fontSize = 34.sp, fontWeight = FontWeight.Bold))
 
         setContent {
-            RenderHtml(
-                html = """
+            MaterialTheme {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .safeDrawingPadding()
+                ) {
+                    RenderHtml(
+                        html = """
                     <h1 style="color: red; font-size: 36px;">Heading 1</h1>
                     <h2 style="color: green;">Heading 2</h2>
                     <p style="font-style: italic; font-weight: 400; font-size: 18px; line-height: 1.5em; text-align: justify; background-color: #f0f0f0;">
@@ -92,7 +105,9 @@ class MainActivity : ComponentActivity() {
                     
                     <p>Mixed inline: <strong>bold</strong>, <em>italic</em>, <a href="https://example.com">link</a>, <sub>sub</sub>, <sup>sup</sup>.</p>
                     """.trimIndent()
-            )
+                    )
+                }
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.0"
 agp = "8.4.1"
-ksoup = "0.2.6"
+ksoup = "0.2.0"
 composeBom = "2024.12.01"
 activityCompose = "1.9.3"
 coil = "3.0.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.0.0"
 agp = "8.4.1"
-jsoup = "1.18.3"
+ksoup = "0.2.6"
 composeBom = "2024.12.01"
 activityCompose = "1.9.3"
 coil = "3.0.4"
@@ -13,7 +13,7 @@ compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = 
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 
 # HTML parsing
-jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 
 # Image Loading (Coil)
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }

--- a/nativehtml/build.gradle.kts
+++ b/nativehtml/build.gradle.kts
@@ -41,6 +41,6 @@ dependencies {
     val composeBom = platform(libs.compose.bom)
     implementation(composeBom)
     implementation(libs.androidx.material3)
-    implementation(libs.jsoup)
+    implementation(libs.ksoup)
     implementation(libs.bundles.coil)
 }

--- a/nativehtml/src/main/java/io/github/malikshairali/nativehtml/parser/HTMLParser.kt
+++ b/nativehtml/src/main/java/io/github/malikshairali/nativehtml/parser/HTMLParser.kt
@@ -19,16 +19,18 @@ import io.github.malikshairali.nativehtml.model.UnorderedList
 import io.github.malikshairali.nativehtml.model.UnsupportedHtml
 import io.github.malikshairali.nativehtml.style.CssParser
 import io.github.malikshairali.nativehtml.style.StyleRegistry
-import org.jsoup.Jsoup
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.TextNode
 
 class HTMLParser {
     fun parse(html: String): List<HTMLElement> {
-        val document = Jsoup.parse(html)
+        val document = Ksoup.parse(html)
         return document.body().children().flatMap { parseElement(it) }
     }
 
     private fun parseElement(
-        element: org.jsoup.nodes.Element,
+        element: Element,
         parentTextStyle: TextStyle = TextStyle()
     ): List<HTMLElement> {
         val tag = element.tagName()
@@ -195,7 +197,7 @@ class HTMLParser {
     }
 
     private fun parseChildren(
-        element: org.jsoup.nodes.Element,
+        element: Element,
         style: TextStyle = TextStyle()
     ): List<HTMLElement> {
         val children = mutableListOf<HTMLElement>()
@@ -203,14 +205,14 @@ class HTMLParser {
         // Iterate through all child nodes (text + elements)
         element.childNodes().forEach { node ->
             when (node) {
-                is org.jsoup.nodes.TextNode -> {
+                is TextNode -> {
                     // Handle plain text nodes
                     if (node.text().isNotBlank()) {
                         children.add(TextElement(text = node.text(), style = style))
                     }
                 }
 
-                is org.jsoup.nodes.Element -> {
+                is Element -> {
                     // Recursively parse child elements
                     children.addAll(
                         parseElement(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three changes in this PR:

### 1. Replace jsoup with ksoup

Replaces `org.jsoup:jsoup` with [`com.fleeksoft.ksoup:ksoup`](https://github.com/fleeksoft/ksoup), a Kotlin Multiplatform port of jsoup. The API is identical so changes are purely mechanical.

- `gradle/libs.versions.toml` — renamed version key `jsoup` → `ksoup = "0.2.0"`, updated module to `com.fleeksoft.ksoup:ksoup`
- `nativehtml/build.gradle.kts` — `implementation(libs.jsoup)` → `implementation(libs.ksoup)`
- `nativehtml/…/parser/HTMLParser.kt` — replaced `org.jsoup.*` imports with `com.fleeksoft.ksoup.*`; `Jsoup.parse` → `Ksoup.parse`
- `README.md` — "Parses HTML using Jsoup" → "Parses HTML using Ksoup"

> **Note on version**: ksoup 0.2.0 (Kotlin 2.0.21) is used rather than 0.2.6 (Kotlin 2.3.10) because the project's Kotlin toolchain is 2.0.0. A library compiled with a newer Kotlin version produces metadata the older compiler cannot read, causing "Cannot access class" errors at compile time. Upgrading to ksoup 0.2.6 would require bumping the project's Kotlin and AGP versions.

### 2. Fix MainActivity so the demo app runs correctly

- `app/build.gradle.kts` — added explicit `compose-bom` + `material3` dependencies
- `app/…/MainActivity.kt` — wrapped `setContent` in `MaterialTheme { Surface { … } }` so Material3 composables have a valid theme; added `enableEdgeToEdge()` + `safeDrawingPadding()` for correct inset handling on modern Android
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37c0fc56-98f6-4f35-8567-ae1b970c5870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37c0fc56-98f6-4f35-8567-ae1b970c5870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

